### PR TITLE
Support CSS column combinator

### DIFF
--- a/include/litehtml/css_selector.h
+++ b/include/litehtml/css_selector.h
@@ -182,13 +182,14 @@ namespace litehtml
 
 	//////////////////////////////////////////////////////////////////////////
 
-	enum css_combinator
-	{
-		combinator_descendant        = ' ',
-		combinator_child             = '>',
-		combinator_adjacent_sibling  = '+',
-		combinator_general_sibling   = '~'
-	};
+        enum css_combinator
+        {
+                combinator_descendant        = ' ',
+                combinator_child             = '>',
+                combinator_adjacent_sibling  = '+',
+                combinator_general_sibling   = '~',
+                combinator_column            = '|'
+        };
 
 	//////////////////////////////////////////////////////////////////////////
 

--- a/src/css_selector.cpp
+++ b/src/css_selector.cpp
@@ -52,11 +52,11 @@ string parse_ns_prefix(const css_token_vector& tokens, int& index)
 		return "";
 	}
 
-	if ((a.type == IDENT || a.ch == '*') && b.ch == '|')
-	{
-		index += 2;
-		return a.type == IDENT ? a.name : "*";
-	}
+        if ((a.type == IDENT || a.ch == '*') && b.ch == '|' && at(tokens, index + 2).ch != '|')
+        {
+                index += 2;
+                return a.type == IDENT ? a.name : "*";
+        }
 
 	return "";
 }
@@ -617,6 +617,12 @@ int parse_combinator(const css_token_vector& tokens, int& index)
 		return tok.ch;
 	}
 
+        if (tok.ch == '|' && at(tokens, index + 1).ch == '|')
+        {
+                index += 2;
+                skip_whitespace(tokens, index);
+                return '|';
+        }
 	return ws ? ' ' : 0;
 }
 

--- a/src/html_tag.cpp
+++ b/src/html_tag.cpp
@@ -447,25 +447,38 @@ int litehtml::html_tag::select(const css_selector& selector, bool apply_pseudo)
 				}
 			}
 			break;
-		case combinator_general_sibling:
-			{
-				bool is_pseudo = false;
-				element::ptr res =  el_parent->find_sibling(shared_from_this(), *selector.m_left, apply_pseudo, &is_pseudo);
-				if(!res)
-				{
-					return select_no_match;
-				} else
-				{
-					if(is_pseudo)
-					{
-						right_res |= select_match_pseudo_class;
-					}
-				}
-			}
-			break;
-		default:
-			right_res = select_no_match;
-		}
+                case combinator_general_sibling:
+                        {
+                                bool is_pseudo = false;
+                                element::ptr res =  el_parent->find_sibling(shared_from_this(), *selector.m_left, apply_pseudo, &is_pseudo);
+                                if(!res)
+                                {
+                                        return select_no_match;
+                                } else
+                                {
+                                        if(is_pseudo)
+                                        {
+                                                right_res |= select_match_pseudo_class;
+                                        }
+                                }
+                        }
+                        break;
+                case combinator_column:
+                        {
+                                bool is_pseudo = false;
+                                element::ptr res = find_ancestor(*selector.m_left, apply_pseudo, &is_pseudo);
+                                if(!res)
+                                {
+                                        return select_no_match;
+                                } else if(is_pseudo)
+                                {
+                                        right_res |= select_match_pseudo_class;
+                                }
+                        }
+                        break;
+                default:
+                        right_res = select_no_match;
+                }
 	}
 	return right_res;
 }

--- a/tests/selector_pseudo_class_test.cpp
+++ b/tests/selector_pseudo_class_test.cpp
@@ -27,3 +27,10 @@ TEST(Selectors, InputPseudoClasses)
     EXPECT_EQ(nullptr, doc2->root()->select_one("input:enabled"));
 }
 
+TEST(Selectors, ColumnCombinatorParse)
+{
+    css_selector sel;
+    ASSERT_TRUE(sel.parse("col||td", litehtml::no_quirks_mode));
+    ASSERT_EQ(combinator_column, sel.m_combinator);
+}
+


### PR DESCRIPTION
## Summary
- extend css_combinator enum for column combinator
- parse `||` as a combinator
- avoid misparsing namespace prefixes followed by `||`
- implement combinator logic in html_tag
- test selector parsing for `||`

## Testing
- `g++ ../tests/selector_pseudo_class_test.cpp -I../include -I.. liblitehtml.a src/gumbo/libgumbo.a /usr/lib/x86_64-linux-gnu/libgtest.a /usr/lib/x86_64-linux-gnu/libgtest_main.a -pthread -std=c++17 -o selector_pseudo_class_test`
- `./selector_pseudo_class_test`

------
https://chatgpt.com/codex/tasks/task_e_6887c3b5b7bc8330abe35707ed3da825