### PR TITLE
Add experimental column layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,10 @@ set(SOURCE_LITEHTML
 	src/line_box.cpp
 	src/css_borders.cpp
 	src/render_item.cpp
-	src/render_block_context.cpp
-	src/render_block.cpp
-	src/render_inline_context.cpp
+        src/render_block_context.cpp
+        src/render_block.cpp
+        src/render_multi_column.cpp
+        src/render_inline_context.cpp
 	src/render_table.cpp
 	src/render_flex.cpp
 	src/render_image.cpp

--- a/demo_columns.html
+++ b/demo_columns.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+<style>
+.multi {
+    column-count: 3;
+    column-gap: 20px;
+    column-rule: 2px solid #888;
+}
+</style>
+</head>
+<body>
+<div class="multi">
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum accumsan.</p>
+<p>Aliquam tincidunt, nunc eget fermentum venenatis, risus quam.</p>
+<p>Suspendisse potenti. Integer lacinia ullamcorper.</p>
+<p>Nulla facilisi. Praesent imperdiet velit id lorem.</p>
+</div>
+</body>
+</html>

--- a/include/litehtml/css_properties.h
+++ b/include/litehtml/css_properties.h
@@ -114,6 +114,14 @@ struct box_shadow
 		caption_side			m_caption_side;
 
 		int 					m_order;
+                css_length                              m_column_count;
+                css_length                              m_column_gap;
+                css_length                              m_column_width;
+                column_fill                             m_column_fill;
+                css_length                              m_column_rule_width;
+                border_style                            m_column_rule_style;
+                web_color                               m_column_rule_color;
+
 
 	private:
 		void compute_font(const html_tag* el, const std::shared_ptr<document>& doc);
@@ -168,7 +176,14 @@ struct box_shadow
 				m_flex_align_items(flex_align_items_stretch),
 				m_flex_align_self(flex_align_items_auto),
 				m_flex_align_content(flex_align_content_stretch),
-				m_order(0)
+				m_order(0),
+                                m_column_count(),
+                                m_column_gap(),
+                                m_column_width(),
+                                m_column_fill(column_fill_balance),
+                                m_column_rule_width(),
+                                m_column_rule_style(border_style_none),
+                                m_column_rule_color(web_color::transparent)
 		{}
 
 		void compute(const html_tag* el, const std::shared_ptr<document>& doc);
@@ -318,6 +333,14 @@ struct box_shadow
                const std::vector<text_shadow>& get_text_shadow_list() const;
                const std::vector<box_shadow>& get_box_shadow_list() const;
                const css_length& get_letter_spacing() const;
+
+               const css_length& get_column_count() const;
+               const css_length& get_column_gap() const;
+               const css_length& get_column_width() const;
+               column_fill get_column_fill() const;
+               const css_length& get_column_rule_width() const;
+               border_style get_column_rule_style() const;
+               const web_color& get_column_rule_color() const;
        };
 
 	inline element_position css_properties::get_position() const
@@ -787,6 +810,41 @@ struct box_shadow
        inline const css_length& css_properties::get_letter_spacing() const
        {
                return m_letter_spacing;
+       }
+
+       inline const css_length& css_properties::get_column_count() const
+       {
+               return m_column_count;
+       }
+
+       inline const css_length& css_properties::get_column_gap() const
+       {
+               return m_column_gap;
+       }
+
+       inline const css_length& css_properties::get_column_width() const
+       {
+               return m_column_width;
+       }
+
+       inline column_fill css_properties::get_column_fill() const
+       {
+               return m_column_fill;
+       }
+
+       inline const css_length& css_properties::get_column_rule_width() const
+       {
+               return m_column_rule_width;
+       }
+
+       inline border_style css_properties::get_column_rule_style() const
+       {
+               return m_column_rule_style;
+       }
+
+       inline const web_color& css_properties::get_column_rule_color() const
+       {
+               return m_column_rule_color;
        }
 }
 

--- a/include/litehtml/document_container.h
+++ b/include/litehtml/document_container.h
@@ -51,6 +51,7 @@ namespace litehtml
 		virtual void				draw_radial_gradient(litehtml::uint_ptr hdc, const background_layer& layer, const background_layer::radial_gradient& gradient) = 0;
 		virtual void				draw_conic_gradient(litehtml::uint_ptr hdc, const background_layer& layer, const background_layer::conic_gradient& gradient) = 0;
 		virtual void				draw_borders(litehtml::uint_ptr hdc, const litehtml::borders& borders, const litehtml::position& draw_pos, bool root) = 0;
+                virtual void                            draw_column_rule(litehtml::uint_ptr hdc, const litehtml::position& draw_pos, int width, border_style style, const web_color& color) {}
 
 		virtual	void				set_caption(const char* caption) = 0;
 		virtual	void				set_base_url(const char* base_url) = 0;

--- a/include/litehtml/render_multi_column.h
+++ b/include/litehtml/render_multi_column.h
@@ -1,0 +1,18 @@
+#ifndef LITEHTML_RENDER_MULTI_COLUMN_H
+#define LITEHTML_RENDER_MULTI_COLUMN_H
+
+#include "render_block_context.h"
+
+namespace litehtml
+{
+        class render_item_multi_column : public render_item_block_context
+        {
+        protected:
+                int _render_content(int x, int y, bool second_pass, const containing_block_context& self_size, formatting_context* fmt_ctx) override;
+        public:
+                explicit render_item_multi_column(std::shared_ptr<element>  el) : render_item_block_context(std::move(el)) {}
+                std::shared_ptr<render_item> clone() override { return std::make_shared<render_item_multi_column>(src_el()); }
+        };
+}
+
+#endif // LITEHTML_RENDER_MULTI_COLUMN_H

--- a/include/litehtml/string_id.h
+++ b/include/litehtml/string_id.h
@@ -315,11 +315,19 @@ STRING_ID(
 	_flex_shrink_,
 	_flex_basis_,
 
-	_caption_side_,
-	_order_,
+        _caption_side_,
+        _order_,
 
-	_counter_reset_,
-	_counter_increment_,
+        _column_count_,
+        _column_gap_,
+        _column_width_,
+        _column_fill_,
+        _column_rule_width_,
+        _column_rule_style_,
+        _column_rule_color_,
+
+        _counter_reset_,
+        _counter_increment_,
 
 	// some CSS dimensions
 	_deg_,

--- a/include/litehtml/types.h
+++ b/include/litehtml/types.h
@@ -1046,6 +1046,14 @@ namespace litehtml
 		flex_basis_max_content,
 	};
 
+#define column_fill_strings             "balance;auto"
+
+        enum column_fill
+        {
+                column_fill_balance,
+                column_fill_auto
+        };
+
 #define caption_side_strings		"top;bottom"
 
 	enum caption_side

--- a/src/css_properties.cpp
+++ b/src/css_properties.cpp
@@ -249,7 +249,15 @@ void litehtml::css_properties::compute(const html_tag* el, const document::ptr& 
 		doc->container()->load_image(m_list_style_image.c_str(), m_list_style_image_baseurl.c_str(), true);
 	}
 
-	m_order = el->get_property<int>(_order_, false, 0, offset(m_order));
+        m_order = el->get_property<int>(_order_, false, 0, offset(m_order));
+
+        m_column_count      = el->get_property<css_length>(_column_count_, false, _auto, offset(m_column_count));
+        m_column_gap        = el->get_property<css_length>(_column_gap_, true, 0, offset(m_column_gap));
+        m_column_width      = el->get_property<css_length>(_column_width_, false, _auto, offset(m_column_width));
+        m_column_fill       = (column_fill)el->get_property<int>(_column_fill_, true, column_fill_balance, offset(m_column_fill));
+        m_column_rule_width = el->get_property<css_length>(_column_rule_width_, true, 0, offset(m_column_rule_width));
+        m_column_rule_style = (border_style)el->get_property<int>(_column_rule_style_, true, border_style_none, offset(m_column_rule_style));
+        m_column_rule_color = get_color_property(el, _column_rule_color_, true, web_color::transparent, offset(m_column_rule_color));
 
 	compute_background(el, doc);
 	compute_flex(el, doc);

--- a/src/render_block.cpp
+++ b/src/render_block.cpp
@@ -1,6 +1,7 @@
 #include "render_block.h"
 #include "render_inline_context.h"
 #include "render_block_context.h"
+#include "render_multi_column.h"
 #include "document.h"
 #include "document_container.h"
 #include "html_tag.h"
@@ -116,7 +117,12 @@ std::shared_ptr<litehtml::render_item> litehtml::render_item_block::init()
     }
     if(has_block_level)
     {
-        ret = std::make_shared<render_item_block_context>(src_el());
+        if(!src_el()->css().get_column_count().is_predefined() || !src_el()->css().get_column_width().is_predefined())
+        {
+            ret = std::make_shared<render_item_multi_column>(src_el());
+        } else {
+            ret = std::make_shared<render_item_block_context>(src_el());
+        }
         ret->parent(parent());
 
         auto doc = src_el()->get_document();

--- a/src/render_multi_column.cpp
+++ b/src/render_multi_column.cpp
@@ -1,0 +1,36 @@
+#include "render_multi_column.h"
+#include "document.h"
+
+int litehtml::render_item_multi_column::_render_content(int x, int y, bool /*second_pass*/, const containing_block_context& self_size, formatting_context* fmt_ctx)
+{
+        int count = 0;
+        if(!css().get_column_count().is_predefined())
+                count = (int)css().get_column_count().val();
+        int gap = css().get_column_gap().calc_percent(self_size.width);
+        if(count <= 0)
+        {
+                if(!css().get_column_width().is_predefined() && css().get_column_width().val() > 0)
+                {
+                        count = std::max(1, static_cast<int>(self_size.render_width / css().get_column_width().val()));
+                }
+        }
+        if(count <= 0) count = 1;
+        int col_width = (self_size.render_width - gap * (count - 1)) / count;
+
+        std::vector<int> col_heights(count, 0);
+        int ret_width = 0;
+
+        int idx = 0;
+        for(const auto& el : m_children)
+        {
+                int col = idx % count;
+                int cx = x + col * (col_width + gap);
+                int cy = y + col_heights[col];
+                int rw = el->render(cx, cy, self_size.new_width(col_width), fmt_ctx);
+                col_heights[col] += el->height();
+                ret_width = std::max(ret_width, rw);
+                idx++;
+        }
+        m_pos.height = *std::max_element(col_heights.begin(), col_heights.end());
+        return ret_width * count + gap * (count - 1);
+}

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -65,7 +65,10 @@ std::map<string_id, string> style::m_valid_values =
 	{ _align_items_, flex_align_items_strings },
 	{ _align_self_, flex_align_items_strings },
 
-	{ _caption_side_, caption_side_strings },
+        { _caption_side_, caption_side_strings },
+
+        { _column_fill_, column_fill_strings },
+        { _column_rule_style_, border_style_strings },
 
 	{ _text_decoration_style_, style_text_decoration_style_strings },
 	{ _text_emphasis_position_, style_text_emphasis_position_strings },
@@ -504,10 +507,44 @@ void style::add_property(string_id name, const css_token_vector& value, const st
 		parse_align_self(name, value, important);
 		break;
 
-	case _order_: // <integer>
-		if (val.type == NUMBER && val.n.number_type == css_number_integer)
-			add_parsed_property(name, property_value((int)val.n.number, important));
-		break;
+        case _order_: // <integer>
+                if (val.type == NUMBER && val.n.number_type == css_number_integer)
+                        add_parsed_property(name, property_value((int)val.n.number, important));
+                break;
+
+        case _column_count_:
+                add_length_property(name, val, "auto", f_integer, important);
+                break;
+
+        case _column_gap_:
+                add_length_property(name, val, "normal", f_length, important);
+                break;
+
+        case _column_width_:
+                add_length_property(name, val, "auto", f_length, important);
+                break;
+
+        case _column_fill_:
+                if (int index = value_index(ident, column_fill_strings); index >= 0)
+                        add_parsed_property(name, property_value(index, important));
+                break;
+
+        case _column_rule_width_:
+                add_length_property(name, val, "medium", f_length, important);
+                break;
+
+        case _column_rule_style_:
+                if (int index = value_index(ident, border_style_strings); index >= 0)
+                        add_parsed_property(name, property_value(index, important));
+                break;
+
+        case _column_rule_color_:
+        {
+                web_color color;
+                if (parse_color(val, color, container))
+                        add_parsed_property(name, property_value(color, important));
+        }
+                break;
 
 	//  =============================  COUNTER, CONTENT  =============================
 


### PR DESCRIPTION
## Summary
- add column-related identifiers
- add column layout properties to css_properties
- parse column properties in style parser
- create a simple multi-column renderer
- example HTML demonstrating columns

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6887c3a97604833086381096c55bf10a